### PR TITLE
A file key may not be an array.

### DIFF
--- a/file.php
+++ b/file.php
@@ -19,6 +19,7 @@ require_once(INCLUDE_DIR.'class.file.php');
 
 //Basic checks
 if (!$_GET['key']
+    || is_array($_GET['key'])
     || !$_GET['signature']
     || !$_GET['expires']
     || !($file = AttachmentFile::lookupByHash($_GET['key']))


### PR DESCRIPTION
If an array is passed, an SQL error is raised, logged and emailed to the administrator.